### PR TITLE
Update pspnet.py

### DIFF
--- a/ptsemseg/models/pspnet.py
+++ b/ptsemseg/models/pspnet.py
@@ -10,7 +10,7 @@ from ptsemseg.models.utils import *
 from ptsemseg.loss import *
 
 pspnet_specs = {
-    'pascalvoc': 
+    'pascal': 
     {
          'n_classes': 21,
          'input_size': (473, 473),


### PR DESCRIPTION
Validation on pascal voc fails due to mismatch in dict key. 